### PR TITLE
Do updates in a buffered update so events can be handled in bulk

### DIFF
--- a/GGDeals/Services/AddResultProcessor.cs
+++ b/GGDeals/Services/AddResultProcessor.cs
@@ -25,12 +25,15 @@ namespace GGDeals.Services
 
 		public void Process(IReadOnlyCollection<Game> games, IDictionary<Guid, AddResult> results)
 		{
-			foreach (var addResult in results)
+			using (_gameStatusService.BufferedUpdate())
 			{
-				var game = games.Single(g => g.Id == addResult.Key);
+				foreach (var addResult in results)
+				{
+					var game = games.Single(g => g.Id == addResult.Key);
 
-				UpdateStatus(game, addResult.Value.Result);
-				AddLink(game, addResult.Value.Url);
+					UpdateStatus(game, addResult.Value.Result);
+					AddLink(game, addResult.Value.Url);
+				}
 			}
 		}
 

--- a/GGDeals/Services/GameStatusService.cs
+++ b/GGDeals/Services/GameStatusService.cs
@@ -68,6 +68,11 @@ namespace GGDeals.Services
             _playniteApi.Database.Games.Update(game);
         }
 
+        public IDisposable BufferedUpdate()
+        {
+            return _playniteApi.Database.BufferedUpdate();
+        }
+
         private Tag EnsureTagExists(AddToCollectionResult status)
         {
             var tagName = _statusToTagMap[status];

--- a/GGDeals/Services/IGameStatusService.cs
+++ b/GGDeals/Services/IGameStatusService.cs
@@ -1,12 +1,15 @@
 ﻿using GGDeals.Models;
 using Playnite.SDK.Models;
+using System;
 
 namespace GGDeals.Services
 {
-	public interface IGameStatusService
-	{
-		AddToCollectionResult GetStatus(Game game);
+    public interface IGameStatusService
+    {
+        AddToCollectionResult GetStatus(Game game);
 
-		void UpdateStatus(Game game, AddToCollectionResult status);
-	}
+        void UpdateStatus(Game game, AddToCollectionResult status);
+
+        IDisposable BufferedUpdate();
+    }
 }


### PR DESCRIPTION
This fixes Metadata Utilities change handlers firing individually for every single game, taking many minutes if you've got a large library to sync all at once.

Not sure how this should be incorporated into the tests, so I didn't.
Might also be cause to regroup the services into one? I don't know. Feel free to take just the idea and incorporate it in some other way.